### PR TITLE
Add figure to reset...

### DIFF
--- a/_generic.reset.scss
+++ b/_generic.reset.scss
@@ -8,7 +8,7 @@
  */
 body,
 h1, h2, h3, h4, h5, h6,
-p, blockquote, pre,
+p, blockquote, pre, figure,
 dl, dd, ol, ul,
 form, fieldset, legend,
 table, th, td, caption,


### PR DESCRIPTION
...because the figure element has default stylings of margin: 1em 40px applied by Normalize.css and I'd like to know why there's no reset for this. So this is merely to start a discussion ;)
